### PR TITLE
Tokenizer improvement

### DIFF
--- a/pybo/tokenizers/tokenize.py
+++ b/pybo/tokenizers/tokenize.py
@@ -32,120 +32,13 @@ class Tokenize:
         went_to_max = False
 
         c_idx = 0
-        while c_idx < len(self.pre_processed.chunks):
-            has_decremented = False
-            is_non_word = False
-            chunk = self.pre_processed.chunks[c_idx]
+        while c_idx <= len(self.pre_processed.chunks):
+            syl, chunk = self.pre_processed.chunks[c_idx]
+            syl = ''.join([self.pre_processed.bs.string[s] for s in syl])
+            self.debug(debug, syl)
 
-            # 1. CHUNK IS SYLLABLE
-            if chunk[0]:
-                # syl is extracted from input string, tsek added for the trie
-                syl = [self.pre_processed.bs.string[c] for c in chunk[0]]  # get letters
-                syl = syl + [TSEK] if syl[-1] != NAMCHE else syl  # add tsek
-                self.debug(debug, syl)
-
-                # >>> WALKING THE TRIE >>>
-                s_idx = 0
-                while s_idx <= len(syl)-1:
-                    # beginning of current syllable
-                    if s_idx == 0:
-                        self.debug(debug, syl[s_idx])
-                        current_node = self.trie.walk(syl[s_idx], current_node)
-                        if current_node and current_node.is_match():
-                            match_data[c_idx] = current_node.data
-
-                    # continuing to walk
-                    elif current_node and current_node.can_walk():
-                        self.debug(debug, syl[s_idx])
-                        current_node = self.trie.walk(syl[s_idx], current_node)
-                        if current_node and current_node.is_match():
-                            match_data[c_idx] = current_node.data
-                # <<<<<<<<<<<<<<<<<<<<<<<<
-
-                        elif not current_node:
-                            if syls:
-                                if not has_decremented:
-                                    c_idx -= 1
-                                    has_decremented = True
-                                went_to_max = True
-                            else:
-                                is_non_word = True
-
-                    # CAN'T CONTINUE WALKING
-                    else:
-                        # a. potential word(syls) is not empty
-                        if syls:
-                            # couldn't walk this syl until the end.
-                            # decrementing chunk-idx for a new attempt to find a match
-                            if not (has_decremented or went_to_max):
-                                c_idx -= 1
-                                has_decremented = True  # ensures we only decrement once per syl
-                            went_to_max = True
-
-                        # b. current word is empty
-                        else:
-                            # there is only a non-word
-                            is_non_word = True
-                    s_idx += 1
-
-                # FINISHED LOOPING OVER CURRENT SYL
-                if is_non_word:
-                    # non-word syls are turned into independant tokens
-                    non_word = [c_idx]
-                    # This syllabe does not exist in the Trie
-                    tokens.append(self.chunks_to_token(non_word, {}, ttype=w.NON_WORD.name))
-                    match_data = {}
-                    syls = []
-
-                else:
-                    if went_to_max:
-                        if not has_decremented:
-                            c_idx -= 1
-                        else:
-                            c_idx = self.add_found_word_or_non_word(c_idx, match_data, syls, tokens, has_decremented)
-                            match_data = {}
-                            syls = []
-                        went_to_max = False
-
-                    else:
-                        syls.append(c_idx)
-                        # end of input and the end of syllable is reached
-                        if c_idx == len(self.pre_processed.chunks) - 1 and s_idx == len(syl):
-                            c_idx = self.add_found_word_or_non_word(c_idx, match_data, syls, tokens, has_decremented)
-                            match_data = {}
-                            syls = []
-                            s_idx += 1
-
-            # 2. CHUNK IS NON-SYLLABLE
-            else:
-                # if there is a word that was not added
-                if syls:
-                    # the word to add ends at c_idx - 1 since we reached the non-syllable chunk
-                    c_idx = self.add_found_word_or_non_word(c_idx - 1, match_data, syls, tokens) + 1
-                    match_data = {}
-                    syls = []
-                    current_node = None
-                    continue
-
-                tokens.append(self.chunks_to_token([c_idx], {}))
-
-            # END OF INPUT
-            # if we reached end of input and there is a non-max-match
-            if len(self.pre_processed.chunks) - 1 == c_idx:
-                if any(match_data.values()) and current_node and not current_node.leaf:
-                    c_idx = self.add_found_word_or_non_word(c_idx, match_data[c_idx], syls, tokens)
-                    syls = []
-                    current_node = None
-                if has_decremented:
-                    c_idx -= 1
 
             c_idx += 1
-
-        # a potential token was left
-        if syls:
-            self.add_found_word_or_non_word(c_idx, match_data[c_idx], syls, tokens)
-
-        self.pre_processed = None
 
         return tokens
 

--- a/pybo/tries/basictrie.py
+++ b/pybo/tries/basictrie.py
@@ -81,9 +81,9 @@ class BasicTrie:
         # parse the word
         current_node = self.head
         exists = True
-        for letter in word:
-            if letter in current_node.children:
-                current_node = current_node.children[letter]
+        for syl in word:
+            if syl in current_node.children:
+                current_node = current_node.children[syl]
             else:
                 exists = False
                 break
@@ -109,9 +109,9 @@ class BasicTrie:
 
         # parse word
         current_node = self.head
-        for letter in word:
-            if letter in current_node.children:
-                current_node = current_node.children[letter]
+        for syl in word:
+            if syl in current_node.children:
+                current_node = current_node.children[syl]
             else:
                 return False
 

--- a/pybo/tries/trie.py
+++ b/pybo/tries/trie.py
@@ -1,4 +1,4 @@
- # coding: utf-8
+# coding: utf-8
 import time
 import pickle
 from pathlib import Path
@@ -161,11 +161,11 @@ class Trie(BasicTrie):
         if not syls:
             return None
 
-        inflected = [(self.__join_syls(syls), None)]
+        inflected = [(syls, None)]
         affixed = self.bosyl.get_all_affixed(syls[-1])
         if affixed:
             for infl, data in affixed:
-                infl_word = self.__join_syls(syls[:-1] + [infl])
+                infl_word = syls[:-1] + [infl]
                 inflected.append((infl_word, {'affixation': data}))
 
         self.tmp_inflected[word] = inflected

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -3,12 +3,16 @@ from pathlib import Path
 from collections import defaultdict
 
 from pybo import Trie, Config
+from pybo import TokChunks
 from pybo import BoSyl
 
 config = Config()
 
 
 def test_createtrie():
+    def syls(string):
+        return TokChunks(string).get_syls()
+
     profile = 'empty'
     modifs = Path(__file__).parent / 'trie_data'
     main, custom = config.get_tok_data_paths(profile, modifs=modifs)
@@ -17,32 +21,35 @@ def test_createtrie():
     # the trie works as expected. but the add() method should never be used directly:
     # it does not inflect entries, so the tokenizer won't work as expected.
     # be careful only to use it with words that can't ever be inflected, like case particles.
-    bt.add('གྲུབ་མཐའ་', {'pos': 'NOUN'})
-    assert bt.has_word('གྲུབ་མཐའི་') == {'exists': False, 'data': {'_': {}}}
+    bt.add(syls('གྲུབ་མཐའ་'), {'pos': 'NOUN'})
+    assert bt.has_word(syls('གྲུབ་མཐའི་')) == {'exists': False, 'data': {'_': {}}}
 
     # use inflect_n_modify_trie() instead, to add entries
     bt.inflect_n_modify_trie('གྲུབ་མཐའ་')
 
-    assert bt.has_word('གྲུབ་མཐའི་') == {'exists': True, 'data': {'_': {}, 'affixation': {'len': 2, 'type': 'gi', 'aa': True}}}
+    assert bt.has_word(syls('གྲུབ་མཐའི་')) == {'exists': True, 'data': {'_': {}, 'affixation': {'len': 2, 'type': 'gi', 'aa': True}}}
 
     bt.inflect_n_modify_trie('ཀ་ར་', skrt=True)
-    assert bt.has_word('ཀ་རར་') == {'exists': True, 'data': {'_': {}, 'affixation': {'len': 1, 'type': 'la', 'aa': False}, 'skrt': True}}  # arrives here because skrt was True
+    assert bt.has_word(syls('ཀ་རར་')) == {'exists': True, 'data': {'_': {}, 'affixation': {'len': 1, 'type': 'la', 'aa': False}, 'skrt': True}}  # arrives here because skrt was True
 
     bt.inflect_n_add_data('གྲུབ་མཐའ་\t\t\t532', freq_only=True)  # 'freq' is hard-coded in Trie, just as 'lemma' and 'pos' are
-    assert bt.has_word('གྲུབ་མཐའི་') == {'exists': True, 'data': {'_': {}, 'affixation': {'len': 2, 'type': 'gi', 'aa': True}, 'form_freq': 532}}  # freq is an int
+    assert bt.has_word(syls('གྲུབ་མཐའི་')) == {'exists': True, 'data': {'_': {}, 'affixation': {'len': 2, 'type': 'gi', 'aa': True}, 'form_freq': 532}}  # freq is an int
 
     # just like add() was not meant to be used directly, deactivate() is not
     # instead, use bt.inflect_n_modify_trie("word", deactivate=True)
-    bt.deactivate('ཀ་ར་')
-    assert bt.has_word('ཀ་རར་')['exists'] is True  # only 'ཀ་ར་' has been deactivated
+    bt.deactivate(syls('ཀ་ར་'))
+    assert bt.has_word(syls('ཀ་རར་'))['exists'] is True  # only 'ཀ་ར་' has been deactivated
 
 
 def test_multiple_words_per_entry():
+    def syls(string):
+        return TokChunks(string).get_syls()
+
     profile = 'POS'
     modifs = Path(__file__).parent / 'trie_data'
     main, custom = config.get_tok_data_paths(profile, modifs=modifs)
     bt = Trie(BoSyl, profile, main, custom)
 
-    res = bt.has_word('ལྟར་')
+    res = bt.has_word(syls('ལྟར་'))
     assert {'lemma': 'ལྟ་', 'pos': 'VERB', 'freq': 123, 'affixed': True} in res['data']['entries']
     assert {'lemma': 'ལྟར་', 'pos': 'ADV', 'freq': 456, 'affixed': False} in res['data']['entries']


### PR DESCRIPTION
The aim of this PR is to:
 A. solve the memory cost of tries (see https://github.com/Esukhia/pybo/issues/56)
 B. simplify drastically [Tokenize.tokenize()](https://github.com/Esukhia/pybo/blob/master/pybo/tokenizers/tokenize.py#L19) so it becomes maintainable.


 A. is solved in 071bdd2f6122ce49f7e4a5c4e67514074719edc5  (see results in https://github.com/Esukhia/pybo/issues/56#issuecomment-522363715)


 B. @10zinten, @ngawangtrinley has agreed that you implement it after ending your work on OpenPoti.

It will be easier to implement the maximal matching algo from scratch.
For each token found (word or non-word), you can use `add_found_word_or_non_word()` to generate the Token objects. (See [here](https://github.com/Esukhia/pybo/blob/master/pybo/tokenizers/tokenize.py#L114) for ex.)

You can use [this failing test](https://github.com/Esukhia/pybo/blob/simpler_tok/tests/test_wordtokenizer.py#L9) as a basis to implement the max-match. Also, ensure the tests in `test_tokenize.py`, `test_bugs.py` and `test_bugs_missing_tokens.py` all pass.

Don't hesitate to reach out for any question.