### PR TITLE
Unexpected syl skip

### DIFF
--- a/botok/tokenizers/tokenize.py
+++ b/botok/tokenizers/tokenize.py
@@ -69,10 +69,9 @@ class Tokenize:
                         else:
                             # check if syllables is NO_POS or Non-word
                             if syls:
-                                self.add_found_word_or_non_word(
+                                c_idx = self.add_found_word_or_non_word(
                                     walker, match_data, syls, tokens
-                                )
-                                c_idx += len(syls)
+                                )# Unexpected syl skip bug fix if chunk to process is in remove word list
                                 break
                             # syllabel is not in the dictionary (Trie)
                             else:
@@ -148,7 +147,7 @@ class Tokenize:
             tokens.append(self.chunks_to_token([syls[0]], {}, ttype=w.NO_POS.name))
 
             # decrement chunk-idx for a new attempt to find a match
-            if syls:
+            if syls and syls[1:]: # Unexpected syl skip bug fix if chunk to process is in remove word list
                 c_idx -= len(syls[1:]) - 1
             if (
                 has_decremented

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -182,6 +182,17 @@ def test_shad_in_syllable():
         ("TEXT", "བཀྲ་"),
     ]
 
+def test_unexpected_skip_syl(wt):
+    input_str = "དེའི་སྒོ་ནས་བསྟན་པ་དང་སེམས་ཅན་ལ་ཕན་ཐོགས་མཛད་ཚུལ།"
+    wt.tok.trie.inflect_n_modify_trie("དང་སེམས་", deactivate=True) # To remove དང་སེམས་ from trie
+    wt.tok.trie.inflect_n_modify_trie("ཕན་ཐོགས་") # to add ཕན་ཐོགས་ to trie
+    tokens = wt.tokenize(input_str)
+    result_str = ''
+    for token in tokens:
+        result_str += f'{token.text} '
+    expected_str = "དེ འི་ སྒོ་ ནས་ བསྟན་པ་ དང་ སེམས་ཅན་ ལ་ ཕན་ཐོགས་ མཛད་ ཚུལ ། "
+    assert expected_str == result_str
+
 
 if __name__ == "__main__":
     test_split_token()


### PR DESCRIPTION
-Input: "ཁ་སང་དང་ཁ་སང་གི་སྔ་ལོ།"
-output: 'ཁ་སང་ དང་ སང་ གི་ སྔ་ལོ ། '

if དང་ཁ་ is in remove word list

expected output: ''ཁ་སང་ དང་ ཁ་སང་ གི་ སྔ་ལོ ། '

This issue has been resolved